### PR TITLE
[NO-TASK]: Fix link "Edit this page on Github"

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -17,7 +17,7 @@ module.exports = {
     logo: "/assets/logo.png",
     editLinks: true,
     editLinkText: "Edit this page on Github",
-    docsBranch: "dev",
+    docsBranch: "develop",
     docsDir: "src",
     lastUpdated: true,
 


### PR DESCRIPTION
Currently these links take you to nowhere. This should fixes it.

<img width="451" alt="Screenshot 2024-11-26 at 10 26 16 AM" src="https://github.com/user-attachments/assets/2e1a2e03-24fc-48ae-8ee7-1c59fda2b9e3">
