### PR TITLE
fix(deploy): pass commit message via env var (multi-line safe)

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -47,9 +47,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           wrangler pages deploy ./src/.vuepress/dist \
             --project-name=deuro-docs-dev \
             --branch=develop \
             --commit-hash=${{ github.sha }} \
-            --commit-message="${{ github.event.head_commit.message }}"
+            --commit-message="$COMMIT_MSG"

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -47,9 +47,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           wrangler pages deploy ./src/.vuepress/dist \
             --project-name=deuro-docs-prd \
             --branch=main \
             --commit-hash=${{ github.sha }} \
-            --commit-message="${{ github.event.head_commit.message }}"
+            --commit-message="$COMMIT_MSG"


### PR DESCRIPTION
GitHub Actions expanding a multi-line commit message directly into a shell argument breaks wrangler. Switching to an env var fixes it.

Previously failed run example: JuiceSwapxyz/documentation run 26468813723 ("Unknown arguments: requires, at, least, Node.js, v22.0.0"). Same bug in all 5 docs repos.