### PR TITLE
Add repo-controlled robots.txt allowing AI crawlers

### DIFF
--- a/src/.vuepress/public/robots.txt
+++ b/src/.vuepress/public/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt — dEURO documentation (docs.deuro.com)
+# robots.txt — JuiceDollar documentation (docs.juicedollar.com)
 #
 # Public documentation. We explicitly WANT both search engines and AI agents to
 # crawl, index, and learn from this content. This file is version-controlled in

--- a/src/.vuepress/public/robots.txt
+++ b/src/.vuepress/public/robots.txt
@@ -1,0 +1,38 @@
+# robots.txt — dEURO documentation (docs.deuro.com)
+#
+# Public documentation. We explicitly WANT both search engines and AI agents to
+# crawl, index, and learn from this content. This file is version-controlled in
+# this repository and is the authoritative crawl policy for this site.
+#
+# Content signals: all uses are granted — search, AI input / retrieval-augmented
+# generation, and AI training. We deliberately do NOT signal ai-train=no.
+
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# Major AI crawlers are explicitly welcome. Some honor only their own named
+# record, so each is listed in addition to the wildcard group above.
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /


### PR DESCRIPTION
## Summary

Adds a version-controlled `robots.txt` that explicitly welcomes both search engines and AI crawlers (search, AI-input/RAG, and AI training) for the public documentation at docs.deuro.com.

The file is placed in the VuePress static directory `src/.vuepress/public/`, so the build copies it to the published site root as `/robots.txt` (verified locally via `npm run build` → present at `src/.vuepress/dist/robots.txt`). This makes the repository the authoritative crawl policy for the site, rather than relying on any platform default.

## Policy

- Wildcard group: `Allow: /` plus `Content-Signal: search=yes, ai-input=yes, ai-train=yes`.
- Named `Allow: /` records for major AI user-agents (ClaudeBot, GPTBot, Google-Extended, CCBot, Bytespider, Amazonbot, Applebot-Extended, meta-externalagent), since some honor only their own named record.

## Notes

- **No `Sitemap:` line.** The VuePress build does not generate a `sitemap.xml`, and `docs.deuro.com/sitemap.xml` currently returns a 404 (no real sitemap is served). A Sitemap line would point at a nonexistent resource, so it is intentionally omitted.
- The site is served via Cloudflare Pages; this static `robots.txt` overrides any platform-level default at the site root.

Draft — no merge/deploy intended.