### PR TITLE
feat: robots.txt — allow all AI crawlers

### DIFF
--- a/src/.vuepress/public/robots.txt
+++ b/src/.vuepress/public/robots.txt
@@ -1,0 +1,38 @@
+# robots.txt — dEURO documentation (docs.deuro.com)
+#
+# Public documentation. We explicitly WANT both search engines and AI agents to
+# crawl, index, and learn from this content. This file is version-controlled in
+# this repository and is the authoritative crawl policy for this site.
+#
+# Content signals: all uses are granted — search, AI input / retrieval-augmented
+# generation, and AI training. We deliberately do NOT signal ai-train=no.
+
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# Major AI crawlers are explicitly welcome. Some honor only their own named
+# record, so each is listed in addition to the wildcard group above.
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /


### PR DESCRIPTION
## What

Adds a repo-controlled `robots.txt` at `src/.vuepress/public/robots.txt` (VuePress copies `public/` verbatim to the site root → served at `/robots.txt`) that explicitly **allows all crawlers, including AI agents**.

## Why

The documentation is public content and should be discoverable by both search engines and AI agents. Sets `User-agent: * → Allow: /`, a positive `Content-Signal: search=yes, ai-input=yes, ai-train=yes` (no `ai-train=no`), and explicit `Allow: /` records for ClaudeBot, GPTBot, Google-Extended, CCBot, Bytespider, Amazonbot, Applebot-Extended, meta-externalagent.

No `Sitemap:` line: `docs.deuro.com/sitemap.xml` is not served (404) and the VuePress build generates none.

## Note

This file becomes the live crawl policy once the site's Cloudflare "Manage robots.txt / Block AI bots" managed setting is disabled for the zone.
